### PR TITLE
Position Command Pop Fix

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
@@ -275,9 +275,11 @@ namespace CarouselView.FormsPlugin.Android
                     SetArrowsVisibility();
                     indicators?.SetViewPager(viewPager);
                     Element.SendPositionSelected();
-                    Element.PositionSelectedCommand?.Execute(null);
-                    if (Element.ItemsSource != null && Element.ItemsSource is INotifyCollectionChanged)
-                        ((INotifyCollectionChanged)Element.ItemsSource).CollectionChanged += ItemsSource_CollectionChanged;
+					if (Element.ItemsSource != null && Element.ItemsSource is INotifyCollectionChanged)
+					{
+						Element.PositionSelectedCommand?.Execute(null);
+						((INotifyCollectionChanged)Element.ItemsSource).CollectionChanged += ItemsSource_CollectionChanged;
+					}
                     break;
                 case "ItemTemplate":
                     viewPager.Adapter = new PageAdapter(Element);

--- a/CarouselView/CarouselView.FormsPlugin.UWP/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.UWP/CarouselViewImplementation.cs
@@ -255,9 +255,11 @@ namespace CarouselView.FormsPlugin.UWP
 					SetNativeView();
                     SetArrowsVisibility();
                     Element.SendPositionSelected();
-					Element.PositionSelectedCommand?.Execute(null);
 					if (Element.ItemsSource != null && Element.ItemsSource is INotifyCollectionChanged)
+					{
+						Element.PositionSelectedCommand?.Execute(null);
 						((INotifyCollectionChanged)Element.ItemsSource).CollectionChanged += ItemsSource_CollectionChanged;
+					}
                     break;
                 case "ItemTemplate":
 					SetNativeView();

--- a/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
@@ -250,9 +250,11 @@ namespace CarouselView.FormsPlugin.iOS
 					SetPosition();
 					SetNativeView();
 					Element.SendPositionSelected();
-                    Element.PositionSelectedCommand?.Execute(null);
 					if (Element.ItemsSource != null && Element.ItemsSource is INotifyCollectionChanged)
+					{
+						Element.PositionSelectedCommand?.Execute(null);
 						((INotifyCollectionChanged)Element.ItemsSource).CollectionChanged += ItemsSource_CollectionChanged;
+					}
 					break;
 				case "ItemTemplate":
 					SetNativeView();


### PR DESCRIPTION
See #7 for more information. 

Summary:
If ItemsSource is `null` it should not trigger PositionSelectedCommand.

This change could result in behavior change in your application so please test before using. 