### PR TITLE
Resize

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.Abstractions/CarouselView.FormsPlugin.Abstractions.csproj
+++ b/CarouselView/CarouselView.FormsPlugin.Abstractions/CarouselView.FormsPlugin.Abstractions.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="2.5.0.122203" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1821" />
   </ItemGroup>
 </Project>

--- a/CarouselView/CarouselView.FormsPlugin.Abstractions/CarouselViewControl.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Abstractions/CarouselViewControl.cs
@@ -1,113 +1,111 @@
 ﻿using System;
-using Xamarin.Forms;
 using System.Collections;
-using System.Linq;
-using System.Collections.Generic;
 using System.ComponentModel;
+using Xamarin.Forms;
 
 namespace CarouselView.FormsPlugin.Abstractions
 {
-	/// <summary>
-	/// CarouselView Interface
-	/// </summary>
+    /// <summary>
+    /// CarouselView Interface
+    /// </summary>
     public class CarouselViewControl : View
-	{
+    {
         public static readonly BindableProperty OrientationProperty = BindableProperty.Create("Orientation", typeof(CarouselViewOrientation), typeof(CarouselViewControl), CarouselViewOrientation.Horizontal);
 
-		public CarouselViewOrientation Orientation
-		{
-			get { return (CarouselViewOrientation)GetValue(OrientationProperty); }
-			set { SetValue(OrientationProperty, value); }
-		}
+        public CarouselViewOrientation Orientation
+        {
+            get { return (CarouselViewOrientation)GetValue(OrientationProperty); }
+            set { SetValue(OrientationProperty, value); }
+        }
 
-		// Android and iOS only
-		public static readonly BindableProperty InterPageSpacingProperty = BindableProperty.Create("InterPageSpacing", typeof(int), typeof(CarouselViewControl), 0);
+        // Android and iOS only
+        public static readonly BindableProperty InterPageSpacingProperty = BindableProperty.Create("InterPageSpacing", typeof(int), typeof(CarouselViewControl), 0);
 
-		public int InterPageSpacing
-		{
-			get { return (int)GetValue(InterPageSpacingProperty); }
-			set { SetValue(InterPageSpacingProperty, value); }
-		}
+        public int InterPageSpacing
+        {
+            get { return (int)GetValue(InterPageSpacingProperty); }
+            set { SetValue(InterPageSpacingProperty, value); }
+        }
 
-		public static readonly BindableProperty IsSwipeEnabledProperty = BindableProperty.Create("IsSwipeEnabled", typeof(bool), typeof(CarouselViewControl), true);
+        public static readonly BindableProperty IsSwipeEnabledProperty = BindableProperty.Create("IsSwipeEnabled", typeof(bool), typeof(CarouselViewControl), true);
 
-		public bool IsSwipeEnabled
-		{
-			get { return (bool)GetValue(IsSwipeEnabledProperty); }
-			set { SetValue(IsSwipeEnabledProperty, value); }
-		}
+        public bool IsSwipeEnabled
+        {
+            get { return (bool)GetValue(IsSwipeEnabledProperty); }
+            set { SetValue(IsSwipeEnabledProperty, value); }
+        }
 
-		public static readonly BindableProperty IndicatorsTintColorProperty = BindableProperty.Create("IndicatorsTintColor", typeof(Color), typeof(CarouselViewControl), Color.Silver);
+        public static readonly BindableProperty IndicatorsTintColorProperty = BindableProperty.Create("IndicatorsTintColor", typeof(Color), typeof(CarouselViewControl), Color.Silver);
 
-		public Color IndicatorsTintColor
-		{
-			get { return (Color)GetValue(IndicatorsTintColorProperty); }
-			set { SetValue(IndicatorsTintColorProperty, value); }
-		}
+        public Color IndicatorsTintColor
+        {
+            get { return (Color)GetValue(IndicatorsTintColorProperty); }
+            set { SetValue(IndicatorsTintColorProperty, value); }
+        }
 
-		public static readonly BindableProperty CurrentPageIndicatorTintColorProperty = BindableProperty.Create("CurrentPageIndicatorTintColor", typeof(Color), typeof(CarouselViewControl), Color.Gray);
+        public static readonly BindableProperty CurrentPageIndicatorTintColorProperty = BindableProperty.Create("CurrentPageIndicatorTintColor", typeof(Color), typeof(CarouselViewControl), Color.Gray);
 
-		public Color CurrentPageIndicatorTintColor
-		{
-			get { return (Color)GetValue(CurrentPageIndicatorTintColorProperty); }
-			set { SetValue(CurrentPageIndicatorTintColorProperty, value); }
-		}
+        public Color CurrentPageIndicatorTintColor
+        {
+            get { return (Color)GetValue(CurrentPageIndicatorTintColorProperty); }
+            set { SetValue(CurrentPageIndicatorTintColorProperty, value); }
+        }
 
-		public static readonly BindableProperty IndicatorsShapeProperty = BindableProperty.Create("IndicatorsShape", typeof(IndicatorsShape), typeof(CarouselViewControl), IndicatorsShape.Circle);
+        public static readonly BindableProperty IndicatorsShapeProperty = BindableProperty.Create("IndicatorsShape", typeof(IndicatorsShape), typeof(CarouselViewControl), IndicatorsShape.Circle);
 
-		public IndicatorsShape IndicatorsShape
-		{
-			get { return (IndicatorsShape)GetValue(IndicatorsShapeProperty); }
-			set { SetValue(IndicatorsShapeProperty, value); }
-		}
+        public IndicatorsShape IndicatorsShape
+        {
+            get { return (IndicatorsShape)GetValue(IndicatorsShapeProperty); }
+            set { SetValue(IndicatorsShapeProperty, value); }
+        }
 
-		public static readonly BindableProperty ShowIndicatorsProperty = BindableProperty.Create("ShowIndicators", typeof(bool), typeof(CarouselViewControl), false);
+        public static readonly BindableProperty ShowIndicatorsProperty = BindableProperty.Create("ShowIndicators", typeof(bool), typeof(CarouselViewControl), false);
 
-		public bool ShowIndicators
-		{
-			get { return (bool)GetValue(ShowIndicatorsProperty); }
-			set { SetValue(ShowIndicatorsProperty, value); }
-		}
+        public bool ShowIndicators
+        {
+            get { return (bool)GetValue(ShowIndicatorsProperty); }
+            set { SetValue(ShowIndicatorsProperty, value); }
+        }
 
-		public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create("ItemsSource", typeof(IEnumerable), typeof(CarouselViewControl), null);
+        public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create("ItemsSource", typeof(IEnumerable), typeof(CarouselViewControl), null);
 
-		public IEnumerable ItemsSource
-		{
-			get { return (IEnumerable)GetValue(ItemsSourceProperty); }
-			set { SetValue(ItemsSourceProperty, value); }
-		}
+        public IEnumerable ItemsSource
+        {
+            get { return (IEnumerable)GetValue(ItemsSourceProperty); }
+            set { SetValue(ItemsSourceProperty, value); }
+        }
 
-		public static readonly BindableProperty ItemTemplateProperty = BindableProperty.Create("ItemTemplate", typeof(DataTemplate), typeof(CarouselViewControl), null);
+        public static readonly BindableProperty ItemTemplateProperty = BindableProperty.Create("ItemTemplate", typeof(DataTemplate), typeof(CarouselViewControl), null);
 
-		public DataTemplate ItemTemplate
-		{
-			get { return (DataTemplate)GetValue(ItemTemplateProperty); }
-			set { SetValue(ItemTemplateProperty, value); }
-		}
+        public DataTemplate ItemTemplate
+        {
+            get { return (DataTemplate)GetValue(ItemTemplateProperty); }
+            set { SetValue(ItemTemplateProperty, value); }
+        }
 
-		public static readonly BindableProperty PositionProperty = BindableProperty.Create("Position", typeof(int), typeof(CarouselViewControl), 0, BindingMode.TwoWay);
+        public static readonly BindableProperty PositionProperty = BindableProperty.Create("Position", typeof(int), typeof(CarouselViewControl), 0, BindingMode.TwoWay);
 
-		public int Position
-		{
-			get { return (int)GetValue(PositionProperty); }
-			set { SetValue(PositionProperty, value); }
-		}
+        public int Position
+        {
+            get { return (int)GetValue(PositionProperty); }
+            set { SetValue(PositionProperty, value); }
+        }
 
-		public static readonly BindableProperty AnimateTransitionProperty = BindableProperty.Create("AnimateTransition", typeof(bool), typeof(CarouselViewControl), true);
+        public static readonly BindableProperty AnimateTransitionProperty = BindableProperty.Create("AnimateTransition", typeof(bool), typeof(CarouselViewControl), true);
 
-		public bool AnimateTransition
-		{
-			get { return (bool)GetValue(AnimateTransitionProperty); }
-			set { SetValue(AnimateTransitionProperty, value); }
-		}
+        public bool AnimateTransition
+        {
+            get { return (bool)GetValue(AnimateTransitionProperty); }
+            set { SetValue(AnimateTransitionProperty, value); }
+        }
 
-		public static readonly BindableProperty ShowArrowsProperty = BindableProperty.Create("ShowArrows", typeof(bool), typeof(CarouselViewControl), false);
+        public static readonly BindableProperty ShowArrowsProperty = BindableProperty.Create("ShowArrows", typeof(bool), typeof(CarouselViewControl), false);
 
-		public bool ShowArrows
-		{
-			get { return (bool)GetValue(ShowArrowsProperty); }
-			set { SetValue(ShowArrowsProperty, value); }
-		}
+        public bool ShowArrows
+        {
+            get { return (bool)GetValue(ShowArrowsProperty); }
+            set { SetValue(ShowArrowsProperty, value); }
+        }
 
         public static readonly BindableProperty ArrowsBackgroundColorProperty = BindableProperty.Create("ArrowsBackgroundColor", typeof(Color), typeof(CarouselViewControl), Color.Black);
 
@@ -145,13 +143,13 @@ namespace CarouselView.FormsPlugin.Abstractions
             set { SetValue(PositionSelectedCommandProperty, value); }
         }
 
-		public event EventHandler<PositionSelectedEventArgs> PositionSelected;
+        public event EventHandler<PositionSelectedEventArgs> PositionSelected;
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		public void SendPositionSelected()
-		{
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SendPositionSelected()
+        {
             PositionSelected?.Invoke(this, new PositionSelectedEventArgs { NewValue = this.Position });
-		}
+        }
 
         public event EventHandler<ScrolledEventArgs> Scrolled;
 
@@ -160,16 +158,23 @@ namespace CarouselView.FormsPlugin.Abstractions
         {
             Scrolled?.Invoke(this, new ScrolledEventArgs { NewValue = percent, Direction = direction });
         }
+
+        public event EventHandler DisposeEvent;
+        public void Dispose()
+        {
+            DisposeEvent?.Invoke(this, null);
+        }
     }
 
-	public class PositionSelectedEventArgs : EventArgs
-	{
-		public int NewValue { get; set; }
-	}
+    public class PositionSelectedEventArgs : EventArgs
+    {
+        public int NewValue { get; set; }
+    }
 
     public class ScrolledEventArgs : EventArgs
     {
         public double NewValue { get; set; }
         public ScrollDirection Direction { get; set; }
     }
+
 }

--- a/CarouselView/CarouselView.FormsPlugin.UWP/CarouselView.FormsPlugin.UWP.csproj
+++ b/CarouselView/CarouselView.FormsPlugin.UWP/CarouselView.FormsPlugin.UWP.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>CarouselView.FormsPlugin.UWP</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
@@ -122,10 +122,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.0.6</Version>
+      <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
-      <Version>2.5.0.122203</Version>
+      <Version>4.8.0.1821</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Using Xamarin 4.8.0.1821
- UWP now scales nicely with no flashing. This is using code from the updated carouselview 6.0.0
- Fixes a memory leak on UWP when resizing. Also added in a dispose event, just in case